### PR TITLE
Update Bytes.sol

### DIFF
--- a/contracts/src/bytes/Bytes.sol
+++ b/contracts/src/bytes/Bytes.sol
@@ -10,7 +10,7 @@ library Bytes {
     /// @dev Concatenate two 'bytes'
     /// @param self The first 'bytes'
     /// @param bts The second 'bytes'
-    /// @returns A new 'bytes' with length 'self.length + bts.length',
+    /// @return A new 'bytes' with length 'self.length + bts.length',
     /// and elements [self[0], ... , self[self.length - 1], bts[0], ... , bts[bts.length - 1]]
     function concat(bytes memory self, bytes memory bts) internal constant returns (bytes memory newBts) {
         uint totLen = self.length + bts.length;


### PR DESCRIPTION
One-character bug fix. Bytes contract was throwing the following error in [browser solidity](https://ethereum.github.io/browser-solidity/#version=soljson-latest.js):

> Error: Doc tag @returns not valid for functions.
